### PR TITLE
fix: add `= null` to optional constructor params

### DIFF
--- a/src/dto/general/Address.php
+++ b/src/dto/general/Address.php
@@ -8,8 +8,8 @@ class Address implements \JsonSerializable
     protected ?string $companyName;
     protected string $address1;
     protected ?string $address2;
-    protected string $street;
-    protected string $houseNr;
+    protected ?string $street;
+    protected ?string $houseNr;
     protected ?string $houseNrExt;
     protected string $postcode;
     protected string $city;
@@ -22,8 +22,8 @@ class Address implements \JsonSerializable
      * @param string|null $companyName
      * @param string $address1
      * @param string|null $address2
-     * @param string $street
-     * @param string $houseNr
+     * @param string|null $street
+     * @param string|null $houseNr
      * @param string|null $houseNrExt
      * @param string $postcode
      * @param string $city
@@ -31,7 +31,7 @@ class Address implements \JsonSerializable
      * @param string|null $state
      * @param string|null $zone
      */
-    public function __construct(string $name, ?string $companyName, string $address1, ?string $address2, string $street, string $houseNr, ?string $houseNrExt, string $postcode, string $city, string $country, ?string $state, ?string $zone)
+    public function __construct(string $name, ?string $companyName = null, string $address1, ?string $address2 = null, ?string $street, ?string $houseNr, ?string $houseNrExt = null, string $postcode, string $city, string $country, ?string $state = null, ?string $zone = null)
     {
         $this->name = $name;
         $this->companyName = $companyName;

--- a/src/dto/general/Client.php
+++ b/src/dto/general/Client.php
@@ -21,7 +21,7 @@ class Client implements \JsonSerializable
      * @param bool|null $filter
      * @param bool|null $transportlabel
      */
-    public function __construct(int $id, ?string $channel, ?string $callback, string $action, ?string $method, ?bool $filter, ?bool $transportlabel)
+    public function __construct(int $id, ?string $channel = null, ?string $callback = null, string $action, ?string $method = null, ?bool $filter = null, ?bool $transportlabel = null)
     {
         $this->id = $id;
         $this->channel = $channel;

--- a/src/dto/general/Customer.php
+++ b/src/dto/general/Customer.php
@@ -15,7 +15,7 @@ class Customer implements \JsonSerializable
      * @param Address|null $billing
      * @param Contact|null $contact
      */
-    public function __construct(?string $id, Address $address, ?Address $billing, ?Contact $contact)
+    public function __construct(?string $id = null, Address $address, ?Address $billing = null, ?Contact $contact = null)
     {
         $this->id = $id;
         $this->address = $address;

--- a/src/dto/general/DangerousGoods.php
+++ b/src/dto/general/DangerousGoods.php
@@ -47,7 +47,7 @@ class DangerousGoods implements \JsonSerializable
      * @param string|null $labels
      * @param int|null $transportCategory
      */
-    public function __construct(?string $technicalName, ?string $shippingName, ?string $mainDanger, ?string $class, ?string $subclass, ?string $packingGroup, ?int $UN, ?int $UNP, ?float $grossMass, ?float $netMass, ?string $massUnit, ?bool $LQ, ?string $NOS, ?bool $environmentHazard, ?string $tunnelCode, ?string $classifactionCode, ?string $packingType, ?string $properties, ?string $labels, ?int $transportCategory)
+    public function __construct(?string $technicalName = null, ?string $shippingName = null, ?string $mainDanger = null, ?string $class = null, ?string $subclass = null, ?string $packingGroup = null, ?int $UN = null, ?int $UNP = null, ?float $grossMass = null, ?float $netMass = null, ?string $massUnit = null, ?bool $LQ = null, ?string $NOS = null, ?bool $environmentHazard = null, ?string $tunnelCode = null, ?string $classifactionCode = null, ?string $packingType = null, ?string $properties = null, ?string $labels = null, ?int $transportCategory = null)
     {
         $this->technicalName = $technicalName;
         $this->shippingName = $shippingName;

--- a/src/dto/general/Package.php
+++ b/src/dto/general/Package.php
@@ -21,7 +21,7 @@ class Package implements \JsonSerializable
      * @param float $width
      * @param float $height
      */
-    public function __construct(?string $warehouse, string $description, ?string $type, float $weight, float $length, float $width, float $height)
+    public function __construct(?string $warehouse = null, string $description, ?string $type = null, float $weight, float $length, float $width, float $height)
     {
         $this->warehouse = $warehouse;
         $this->description = $description;

--- a/src/dto/general/Product.php
+++ b/src/dto/general/Product.php
@@ -56,7 +56,7 @@ class Product implements \JsonSerializable
      * @param string|null $custom4
      * @param string|null $custom5
      */
-    public function __construct(?string $id, ?int $packageNum, ?int $warehouse, ?bool $transportlabel, ?string $location, ?string $description, ?string $content, ?string $SKU, ?string $hsCode, ?DangerousGoods $dangerousGoods, float $quantity, float $value, float $weight, float $length, float $width, float $height, ?bool $stock, ?DateTime $stockdate, ?WareHouse $warehouses, ?string $custom1, ?string $custom2, ?string $custom3, ?string $custom4, ?string $custom5)
+    public function __construct(?string $id = null, ?int $packageNum = null, ?int $warehouse = null, ?bool $transportlabel = null, ?string $location = null, ?string $description = null, ?string $content = null, ?string $SKU = null, ?string $hsCode = null, ?DangerousGoods $dangerousGoods = null, float $quantity, float $value, float $weight, float $length, float $width, float $height, ?bool $stock = null, ?DateTime $stockdate = null, ?WareHouse $warehouses = null, ?string $custom1 = null, ?string $custom2 = null, ?string $custom3 = null, ?string $custom4 = null, ?string $custom5 = null)
     {
         $this->id = $id;
         $this->packageNum = $packageNum;

--- a/src/dto/general/Shipment.php
+++ b/src/dto/general/Shipment.php
@@ -56,7 +56,7 @@ class Shipment implements \JsonSerializable
      * @param string|null $printerchannel
      * @param string|null $getdiscounts
      */
-    public function __construct(string $orderNumber, string $reference, string $language, string $currency, ?DateTime $firstPickUpDate, ?DateTime $firstPickUpDateTime, ?string $carrier, ?string $service, ?DateTime $deliveryTimeFrom, ?DateTime $deliveryTimeTo, ?bool $inbound, ?int $numPallets, ?bool $cod, ?bool $signature, ?bool $noNeighbor, ?bool $insured, ?string $incoterm, ?string $route, ?string $warehousezone, ?string $batch, ?string $note, ?string $instructions, ?string $printerchannel, ?string $getdiscounts)
+    public function __construct(string $orderNumber, string $reference, string $language, string $currency, ?DateTime $firstPickUpDate = null, ?DateTime $firstPickUpDateTime = null, ?string $carrier = null, ?string $service = null, ?DateTime $deliveryTimeFrom = null, ?DateTime $deliveryTimeTo = null, ?bool $inbound = null, ?int $numPallets = null, ?bool $cod = null, ?bool $signature = null, ?bool $noNeighbor = null, ?bool $insured = null, ?string $incoterm = null, ?string $route = null, ?string $warehousezone = null, ?string $batch = null, ?string $note = null, ?string $instructions = null, ?string $printerchannel = null, ?string $getdiscounts = null)
     {
         $this->orderNumber = $orderNumber;
         $this->reference = $reference;

--- a/src/dto/general/Warehouse.php
+++ b/src/dto/general/Warehouse.php
@@ -12,7 +12,7 @@ class Warehouse implements \JsonSerializable
      * @param int|null $id
      * @param DateTime|null $stockdate
      */
-    public function __construct(?int $id, ?DateTime $stockdate)
+    public function __construct(?int $id = null, ?DateTime $stockdate = null)
     {
         $this->id = $id;
         $this->stockdate = $stockdate;

--- a/src/dto/general/updates/ShipmentUpdate.php
+++ b/src/dto/general/updates/ShipmentUpdate.php
@@ -21,7 +21,7 @@ class ShipmentUpdate implements \JsonSerializable
      * @param int|null $labelSequence
      * @param bool|null $endOfShipment
      */
-    public function __construct(int $id, ?string $status, ?string $orderNumber, ?string $reference, ?string $note, ?int $labelSequence, ?bool $endOfShipment)
+    public function __construct(int $id, ?string $status = null, ?string $orderNumber = null, ?string $reference = null, ?string $note = null, ?int $labelSequence = null, ?bool $endOfShipment = null)
     {
         $this->id = $id;
         $this->status = $status;

--- a/src/dto/requests/GetDesignRequest.php
+++ b/src/dto/requests/GetDesignRequest.php
@@ -11,7 +11,7 @@ class GetDesignRequest implements \JsonSerializable
      * @param string|null $language
      * @param bool|null $logo
      */
-    public function __construct(?string $language, ?bool $logo)
+    public function __construct(?string $language = null, ?bool $logo = null)
     {
         $this->language = $language;
         $this->logo = $logo;

--- a/src/dto/requests/GetLabelRequest.php
+++ b/src/dto/requests/GetLabelRequest.php
@@ -15,7 +15,7 @@ class GetLabelRequest implements \JsonSerializable
      * @param int|null $sequence
      * @param bool|null $endOfShipment
      */
-    public function __construct(?int $id, ?string $orderNumber, ?int $sequence, ?bool $endOfShipment)
+    public function __construct(?int $id = null, ?string $orderNumber = null, ?int $sequence = null, ?bool $endOfShipment = null)
     {
         $this->id = $id;
         $this->orderNumber = $orderNumber;

--- a/src/dto/requests/GetShipmentsRequest.php
+++ b/src/dto/requests/GetShipmentsRequest.php
@@ -18,7 +18,7 @@ class GetShipmentsRequest implements \JsonSerializable
      * @param string|null $status
      * @param string|null $channel
      */
-    public function __construct(DateTime $dateFrom, DateTime $dateTo, ?string $status, ?string $channel)
+    public function __construct(DateTime $dateFrom, DateTime $dateTo, ?string $status = null, ?string $channel = null)
     {
         $this->dateFrom = $dateFrom;
         $this->dateTo = $dateTo;

--- a/src/dto/requests/InsertShipmentRequest.php
+++ b/src/dto/requests/InsertShipmentRequest.php
@@ -36,7 +36,7 @@ class InsertShipmentRequest implements \JsonSerializable
      * @param float|null $priceExcl
      * @param float|null $weight
      */
-    public function __construct(Client $client, Shipment $shipment, ?Sender $sender, ?Customer $customer, ?Packages $packages, ?Quote $quote, ?bool $fragileGoods, ?bool $dangerousGoods, ?float $priceIncl, ?float $priceExcl, ?float $weight)
+    public function __construct(Client $client, Shipment $shipment, ?Sender $sender = null, ?Customer $customer = null, ?Packages $packages = null, ?Quote $quote = null, ?bool $fragileGoods = null, ?bool $dangerousGoods = null, ?float $priceIncl = null, ?float $priceExcl = null, ?float $weight = null)
     {
         $this->client = $client;
         $this->shipment = $shipment;

--- a/src/dto/requests/UpdateShipmentMethodRequest.php
+++ b/src/dto/requests/UpdateShipmentMethodRequest.php
@@ -18,7 +18,7 @@ class UpdateShipmentMethodRequest implements \JsonSerializable {
      * @param DateTime|null $date
      * @param string|null $action
      */
-    public function __construct(int $id, ?string $orderNumber, string $methodId, ?DateTime $date, ?string $action)
+    public function __construct(int $id, ?string $orderNumber = null, string $methodId, ?DateTime $date = null, ?string $action = null)
     {
         $this->id = $id;
         $this->orderNumber = $orderNumber;

--- a/src/dto/requests/UpdateShipmentRequest.php
+++ b/src/dto/requests/UpdateShipmentRequest.php
@@ -37,7 +37,7 @@ class UpdateShipmentRequest implements \JsonSerializable
      * @param float|null $priceExcl
      * @param float|null $weight
      */
-    public function __construct(Client $client, ShipmentUpdate $shipment, ?Sender $sender, ?Customer $customer, ?Packages $packages, ?Quote $quote, ?bool $fragileGoods, ?bool $dangerousGoods, ?float $priceIncl, ?float $priceExcl, ?float $weight)
+    public function __construct(Client $client, ShipmentUpdate $shipment, ?Sender $sender = null, ?Customer $customer = null, ?Packages $packages = null, ?Quote $quote = null, ?bool $fragileGoods = null, ?bool $dangerousGoods = null, ?float $priceIncl = null, ?float $priceExcl = null, ?float $weight = null)
     {
         $this->client = $client;
         $this->shipment = $shipment;


### PR DESCRIPTION
Adjust nullable params in the constructors to include `= null` so the param does not need to be added and set to null when creating an object. Maintains the same parameter order for existing setups with the library